### PR TITLE
Caching strategy (DB part)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,24 +59,24 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out code
 
-      - uses: docker/setup-qemu-action@v2.0.0
+      - uses: docker/setup-qemu-action@v2
         name: Set up QEMU
 
-      - uses: docker/setup-buildx-action@v2.5.0
+      - uses: docker/setup-buildx-action@v2
         name: Set up Docker Buildx
 
-      - uses: docker/login-action@v2.1.0
+      - uses: docker/login-action@v2
         name: Login to DockerHub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v4.0.0
+      - uses: docker/build-push-action@v4
         name: Build and push
         id: docker_build
         with:
           push: true
-          #       platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           tags: "ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
 
       - name: Run Trivy vulnerability scanner

--- a/dcs/adapters/outbound/dao.py
+++ b/dcs/adapters/outbound/dao.py
@@ -33,6 +33,6 @@ class DrsObjectDaoConstructor:
 
         return await dao_factory.get_dao(
             name="drs_objects",
-            dto_model=models.DrsObject,
+            dto_model=models.AccessTimeDrsObject,
             id_field="file_id",
         )

--- a/dcs/core/auth_policies.py
+++ b/dcs/core/auth_policies.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 """Supported authentication policies for endpoints"""
 
-from typing import Literal, Union
+try:  # workaround for https://github.com/pydantic/pydantic/issues/5821
+    from typing_extensions import Literal
+except ImportError:
+    from typing import Literal  # type: ignore
+
+from typing import Union
 
 from ghga_service_commons.utils.crypt import decode_key
 from pydantic import BaseModel, EmailStr, Field, validator

--- a/dcs/core/data_repository.py
+++ b/dcs/core/data_repository.py
@@ -16,8 +16,8 @@
 """Main business-logic of this service"""
 
 import re
-from datetime import datetime
 
+from ghga_service_commons.utils import utc_dates
 from pydantic import BaseSettings, Field, PositiveInt, validator
 
 from dcs.adapters.outbound.http import exceptions
@@ -153,7 +153,7 @@ class DataRepository(DataRepositoryPort):
             )
 
         # Successfully staged, update access information now
-        drs_object_with_access_time.last_accessed = datetime.utcnow()
+        drs_object_with_access_time.last_accessed = utc_dates.now_as_utc()
         try:
             await self._drs_object_dao.update(drs_object_with_access_time)
         except ResourceNotFoundError as error:
@@ -174,7 +174,7 @@ class DataRepository(DataRepositoryPort):
         """Register a file as a new DRS Object."""
 
         file_with_access_time = models.AccessTimeDrsObject(
-            **file.dict(), last_accessed=datetime.utcnow()
+            **file.dict(), last_accessed=utc_dates.now_as_utc()
         )
         # write file entry to database
         await self._drs_object_dao.insert(file_with_access_time)

--- a/dcs/core/models.py
+++ b/dcs/core/models.py
@@ -17,6 +17,7 @@
 in the api."""
 
 import re
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, validator
@@ -52,6 +53,14 @@ class DrsObject(BaseModel):
     decrypted_sha256: str
     decrypted_size: int
     creation_date: str
+
+
+class AccessTimeDrsObject(DrsObject):
+    """
+    DRS Model with information for outbox caching strategy
+    """
+
+    last_accessed: datetime
 
 
 class DrsObjectWithUri(DrsObject):

--- a/dcs/core/models.py
+++ b/dcs/core/models.py
@@ -17,7 +17,12 @@
 in the api."""
 
 import re
-from typing import Literal
+
+try:  # workaround for https://github.com/pydantic/pydantic/issues/5821
+    from typing_extensions import Literal
+except ImportError:
+    from typing import Literal  # type: ignore
+
 
 from ghga_service_commons.utils import utc_dates
 from pydantic import BaseModel, validator

--- a/dcs/core/models.py
+++ b/dcs/core/models.py
@@ -17,9 +17,9 @@
 in the api."""
 
 import re
-from datetime import datetime
 from typing import Literal
 
+from ghga_service_commons.utils import utc_dates
 from pydantic import BaseModel, validator
 
 
@@ -60,7 +60,7 @@ class AccessTimeDrsObject(DrsObject):
     DRS Model with information for outbox caching strategy
     """
 
-    last_accessed: datetime
+    last_accessed: utc_dates.DateTimeUTC
 
 
 class DrsObjectWithUri(DrsObject):

--- a/dcs/ports/outbound/dao.py
+++ b/dcs/ports/outbound/dao.py
@@ -25,4 +25,4 @@ from hexkit.protocols.dao import (  # noqa: F401
 from dcs.core import models
 
 # port described by a type alias:
-DrsObjectDaoPort = DaoNaturalId[models.DrsObject]
+DrsObjectDaoPort = DaoNaturalId[models.AccessTimeDrsObject]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[all]==0.3.1
+    ghga-service-commons[all]==0.3.2
     ghga-event-schemas==0.8.0
     hexkit[mongodb,s3,akafka]==0.9.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[api,auth,crypt]==0.3.0
+    ghga-service-commons[api,auth,crypt]==0.3.1
     ghga-event-schemas==0.8.0
     hexkit[mongodb,s3,akafka]==0.9.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[api,auth,crypt]==0.3.1
+    ghga-service-commons[all]==0.3.1
     ghga-event-schemas==0.8.0
     hexkit[mongodb,s3,akafka]==0.9.2
 

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -35,7 +35,7 @@ import httpx
 import pytest_asyncio
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_service_commons.api.testing import AsyncTestClient
-from ghga_service_commons.utils import jwt_helpers
+from ghga_service_commons.utils import jwt_helpers, utc_dates
 from ghga_service_commons.utils.crypt import encode_key, generate_key_pair
 from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture
 from hexkit.providers.mongodb.testutils import MongoDbFixture  # F401
@@ -56,7 +56,7 @@ EXAMPLE_FILE = models.AccessTimeDrsObject(
     creation_date=datetime.now().isoformat(),
     decrypted_size=12345,
     decryption_secret_id="some-secret",
-    last_accessed=datetime.utcnow(),
+    last_accessed=utc_dates.now_as_utc(),
 )
 
 SignedToken = str

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -50,12 +50,13 @@ from dcs.main import get_configured_container, get_rest_api
 from tests.fixtures.config import get_config
 from tests.fixtures.mock_api.testcontainer import MockAPIContainer
 
-EXAMPLE_FILE = models.DrsObject(
+EXAMPLE_FILE = models.AccessTimeDrsObject(
     file_id="examplefile001",
     decrypted_sha256="0677de3685577a06862f226bb1bfa8f889e96e59439d915543929fb4f011d096",
     creation_date=datetime.now().isoformat(),
     decrypted_size=12345,
     decryption_secret_id="some-secret",
+    last_accessed=datetime.utcnow(),
 )
 
 SignedToken = str


### PR DESCRIPTION
```
DRS DAO model now includes time it was last accessed
```

This should only affect what is stored in the DB, as the retrieved model is converted to the old DrsObject that all other variants still derive from.
Used `utcnow` as default, as the clean up script will check from the perspective of objects in the outbox bucket. 
The choice does not matter that much as this is set to the current time on the next call after successful staging either way.