### PR TITLE
Incorporate S3 object ID (GSI-194)

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -10,7 +10,7 @@ python -m pip install --upgrade pip
 pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
-pip install --upgrade -r requirements-dev.txt
+pip install -r requirements-dev.txt
 
 # install pre-commit hooks to git
 pre-commit install

--- a/dcs/adapters/inbound/event_sub.py
+++ b/dcs/adapters/inbound/event_sub.py
@@ -83,7 +83,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileInternallyRegistered
         )
 
-        object_id = uuid.uuid4()
+        object_id = str(uuid.uuid4())
 
         file = models.DrsObject(
             file_id=validated_payload.file_id,

--- a/dcs/adapters/inbound/event_sub.py
+++ b/dcs/adapters/inbound/event_sub.py
@@ -15,7 +15,6 @@
 
 """Adapter for receiving events providing metadata on files"""
 
-import uuid
 
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.validation import get_validated_payload
@@ -83,11 +82,8 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileInternallyRegistered
         )
 
-        object_id = str(uuid.uuid4())
-
-        file = models.DrsObject(
+        file = models.DrsObjectBase(
             file_id=validated_payload.file_id,
-            object_id=object_id,
             decryption_secret_id=validated_payload.decryption_secret_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,

--- a/dcs/adapters/inbound/event_sub.py
+++ b/dcs/adapters/inbound/event_sub.py
@@ -15,6 +15,8 @@
 
 """Adapter for receiving events providing metadata on files"""
 
+import uuid
+
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
@@ -81,8 +83,11 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileInternallyRegistered
         )
 
+        object_id = uuid.uuid4()
+
         file = models.DrsObject(
             file_id=validated_payload.file_id,
+            object_id=object_id,
             decryption_secret_id=validated_payload.decryption_secret_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,

--- a/dcs/adapters/inbound/fastapi_/routes.py
+++ b/dcs/adapters/inbound/fastapi_/routes.py
@@ -108,7 +108,8 @@ async def get_drs_object(
     data_repository: DataRepositoryPort = Depends(Provide[Container.data_repository]),
 ):
     """
-    Get info about a ``DrsObject``.
+    Get info about a ``DrsObject``. The object_id parameter refers to the file id
+    and **not** the S3 object id.
     """
 
     if not work_order_context.file_id == object_id:
@@ -152,7 +153,8 @@ async def get_envelope(  # noqa: C901
 ):
     """
     Retrieve the base64 encoded envelope for a given object based on object id and
-    URL safe base64 encoded public key
+    URL safe base64 encoded public key. The object_id parameter refers to the file id
+    and **not** the S3 object id.
     """
 
     if not work_order_context.file_id == object_id:

--- a/dcs/adapters/outbound/event_pub.py
+++ b/dcs/adapters/outbound/event_pub.py
@@ -121,13 +121,19 @@ class EventPubTranslator(EventPublisherPort):
         )
 
     async def unstaged_download_requested(
-        self, *, drs_object: models.DrsObjectWithUri
+        self,
+        *,
+        drs_object: models.DrsObjectWithUri,
+        target_bucket_id: str,
     ) -> None:
         """Communicates the event that a download was requested for a file that
         is not yet available in the outbox."""
 
         payload = event_schemas.NonStagedFileRequested(
-            file_id=drs_object.file_id, decrypted_sha256=drs_object.decrypted_sha256
+            file_id=drs_object.file_id,
+            target_object_id=drs_object.object_id,
+            target_bucket_id=target_bucket_id,
+            decrypted_sha256=drs_object.decrypted_sha256,
         )
         payload_dict = json.loads(payload.json())
 

--- a/dcs/adapters/outbound/event_pub.py
+++ b/dcs/adapters/outbound/event_pub.py
@@ -102,12 +102,16 @@ class EventPubTranslator(EventPublisherPort):
         self._config = config
         self._provider = provider
 
-    async def download_served(self, *, drs_object: models.DrsObjectWithUri) -> None:
+    async def download_served(
+        self, *, drs_object: models.DrsObjectWithUri, target_bucket_id: str
+    ) -> None:
         """Communicate the event of a download being served. This can be relevant for
         auditing purposes."""
 
         payload = event_schemas.FileDownloadServed(
             file_id=drs_object.file_id,
+            target_object_id=drs_object.object_id,
+            target_bucket_id=target_bucket_id,
             decrypted_sha256=drs_object.decrypted_sha256,
             context="unknown",
         )

--- a/dcs/core/data_repository.py
+++ b/dcs/core/data_repository.py
@@ -261,7 +261,7 @@ class DataRepository(DataRepositoryPort):
                 api_url=self._config.ekss_base_url
             ) from error
         except exceptions.SecretNotFoundError as error:
-            raise self.EnvelopeNotFoundError(object_id=drs_id) from error
+            raise self.EnvelopeNotFoundError(object_id=drs_object.object_id) from error
 
         return envelope
 

--- a/dcs/core/data_repository.py
+++ b/dcs/core/data_repository.py
@@ -154,7 +154,8 @@ class DataRepository(DataRepositoryPort):
         ):
             # publish an event to request a stage of the corresponding file:
             await self._event_publisher.unstaged_download_requested(
-                drs_object=drs_object_with_uri
+                drs_object=drs_object_with_uri,
+                target_bucket_id=self._config.outbox_bucket,
             )
 
             # instruct to retry later:

--- a/dcs/core/data_repository.py
+++ b/dcs/core/data_repository.py
@@ -286,7 +286,7 @@ class DataRepository(DataRepositoryPort):
         # Try to remove file from S3
         try:
             await self._object_storage.delete_object(
-                bucket_id=self._config.outbox_bucket, object_id=file_id
+                bucket_id=self._config.outbox_bucket, object_id=drs_object.object_id
             )
 
         except self._object_storage.ObjectNotFoundError:

--- a/dcs/core/models.py
+++ b/dcs/core/models.py
@@ -48,17 +48,22 @@ class Checksum(BaseModel):
     type: Literal["sha-256"] = "sha-256"
 
 
-class DrsObject(BaseModel):
+class DrsObjectBase(BaseModel):
     """
     A model containing the metadata needed to register a new DRS object.
     """
 
     file_id: str
-    object_id: str
     decryption_secret_id: str
     decrypted_sha256: str
     decrypted_size: int
     creation_date: str
+
+
+class DrsObject(DrsObjectBase):
+    """A DrsObjectBase with the object_id generated"""
+
+    object_id: str
 
 
 class AccessTimeDrsObject(DrsObject):

--- a/dcs/core/models.py
+++ b/dcs/core/models.py
@@ -54,6 +54,7 @@ class DrsObject(BaseModel):
     """
 
     file_id: str
+    object_id: str
     decryption_secret_id: str
     decrypted_sha256: str
     decrypted_size: int

--- a/dcs/ports/inbound/data_repository.py
+++ b/dcs/ports/inbound/data_repository.py
@@ -101,7 +101,7 @@ class DataRepositoryPort(ABC):
         ...
 
     @abstractmethod
-    async def register_new_file(self, *, file: models.DrsObject):
+    async def register_new_file(self, *, file: models.DrsObjectBase):
         """Register a file as a new DRS Object."""
         ...
 

--- a/dcs/ports/outbound/event_pub.py
+++ b/dcs/ports/outbound/event_pub.py
@@ -24,7 +24,9 @@ class EventPublisherPort(ABC):
     """A port through which DRS-specific events are communicated with the outside."""
 
     @abstractmethod
-    async def download_served(self, *, drs_object: models.DrsObjectWithUri) -> None:
+    async def download_served(
+        self, *, drs_object: models.DrsObjectWithUri, target_bucket_id: str
+    ) -> None:
         """Communicate the event of an download being served. This can be relevant for
         auditing purposes."""
         ...

--- a/dcs/ports/outbound/event_pub.py
+++ b/dcs/ports/outbound/event_pub.py
@@ -31,7 +31,7 @@ class EventPublisherPort(ABC):
 
     @abstractmethod
     async def unstaged_download_requested(
-        self, *, drs_object: models.DrsObjectWithUri
+        self, *, drs_object: models.DrsObjectWithUri, target_bucket_id: str
     ) -> None:
         """Communicates the event that a download was requested for a file that
         is not yet available in the outbox."""

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -277,7 +277,10 @@ paths:
       - DownloadControllerService
   /objects/{object_id}:
     get:
-      description: Get info about a ``DrsObject``.
+      description: 'Get info about a ``DrsObject``. The object_id parameter refers
+        to the file id
+
+        and **not** the S3 object id.'
       operationId: getDrsObject
       parameters:
       - in: path
@@ -337,7 +340,10 @@ paths:
       description: 'Retrieve the base64 encoded envelope for a given object based
         on object id and
 
-        URL safe base64 encoded public key'
+        URL safe base64 encoded public key. The object_id parameter refers to the
+        file id
+
+        and **not** the S3 object id.'
       operationId: getEnvelope
       parameters:
       - in: path

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 install_requires =
     typer==0.7.0
     ghga-service-commons[all]==0.3.2
-    ghga-event-schemas==0.11.0
+    ghga-event-schemas==0.13.0
     hexkit[mongodb,s3,akafka]==0.10.0
 
 python_requires = >= 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 install_requires =
     typer==0.7.0
     ghga-service-commons[all]==0.3.2
-    ghga-event-schemas==0.13.0
+    ghga-event-schemas==0.13.1
     hexkit[mongodb,s3,akafka]==0.10.0
 
 python_requires = >= 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[all]==0.3.2
+    ghga-service-commons[all]==0.4.1
     ghga-event-schemas==0.13.1
     hexkit[mongodb,s3,akafka]==0.10.0
 

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -55,6 +55,7 @@ from tests.fixtures.mock_api.testcontainer import MockAPIContainer
 
 EXAMPLE_FILE = models.AccessTimeDrsObject(
     file_id="examplefile001",
+    object_id="object001",
     decrypted_sha256="0677de3685577a06862f226bb1bfa8f889e96e59439d915543929fb4f011d096",
     creation_date=datetime.now().isoformat(),
     decrypted_size=12345,
@@ -163,6 +164,7 @@ class PopulatedFixture:
     """Returned by `populated_fixture()`."""
 
     drs_id: str
+    object_id: str
     example_file: models.AccessTimeDrsObject
     joint_fixture: JointFixture
 
@@ -175,6 +177,8 @@ async def populated_fixture(
     # publish an event to register a new file for download:
     files_to_register_event = event_schemas.FileInternallyRegistered(
         file_id=EXAMPLE_FILE.file_id,
+        source_object_id=EXAMPLE_FILE.object_id,
+        source_bucket_id=joint_fixture.config.outbox_bucket,
         upload_date=EXAMPLE_FILE.creation_date,
         decrypted_size=EXAMPLE_FILE.decrypted_size,
         decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
@@ -210,6 +214,12 @@ async def populated_fixture(
     assert file_registered_event.decrypted_sha256 == EXAMPLE_FILE.decrypted_sha256
     assert file_registered_event.upload_date == EXAMPLE_FILE.creation_date
 
+    # get the object id that was generated upon event consumption
+    dao = await joint_fixture.container.drs_object_dao()
+    drs_object = await dao.get_by_id(EXAMPLE_FILE.file_id)
+    object_id = drs_object.object_id
+
+    # generate work order token
     work_order_token, pubkey = get_work_order_token(  # noqa: F405
         file_id=EXAMPLE_FILE.file_id,
         valid_seconds=120,
@@ -224,6 +234,7 @@ async def populated_fixture(
 
     yield PopulatedFixture(
         drs_id=EXAMPLE_FILE.file_id,
+        object_id=object_id,
         example_file=EXAMPLE_FILE,
         joint_fixture=joint_fixture,
     )
@@ -248,10 +259,12 @@ async def cleanup_fixture(
     # create AccessTimeDrsObjects for valid cached and expired cached file
     test_file_cached = EXAMPLE_FILE.copy(deep=True)
     test_file_cached.file_id = "cached"
+    test_file_cached.object_id = "cached"
     test_file_cached.last_accessed = utc_dates.now_as_utc()
 
     test_file_expired = EXAMPLE_FILE.copy(deep=True)
     test_file_expired.file_id = "expired"
+    test_file_expired.object_id = "expired"
     test_file_expired.last_accessed = utc_dates.now_as_utc() - timedelta(
         days=joint_fixture.config.cache_timeout
     )
@@ -267,11 +280,12 @@ async def cleanup_fixture(
 
     # populate storage
     with temp_file_object(
-        bucket_id=joint_fixture.config.outbox_bucket, object_id=test_file_cached.file_id
+        bucket_id=joint_fixture.config.outbox_bucket,
+        object_id=test_file_cached.object_id,
     ) as cached_file:
         with temp_file_object(
             bucket_id=joint_fixture.config.outbox_bucket,
-            object_id=test_file_expired.file_id,
+            object_id=test_file_expired.object_id,
         ) as expired_file:
             await joint_fixture.s3.populate_file_objects([cached_file, expired_file])
 

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -177,8 +177,8 @@ async def populated_fixture(
     # publish an event to register a new file for download:
     files_to_register_event = event_schemas.FileInternallyRegistered(
         file_id=EXAMPLE_FILE.file_id,
-        source_object_id=EXAMPLE_FILE.object_id,
-        source_bucket_id=joint_fixture.config.outbox_bucket,
+        object_id=EXAMPLE_FILE.object_id,
+        bucket_id=joint_fixture.config.outbox_bucket,
         upload_date=EXAMPLE_FILE.creation_date,
         decrypted_size=EXAMPLE_FILE.decrypted_size,
         decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -39,6 +39,7 @@ async def test_happy_journey(
     drs_id = populated_fixture.drs_id
     example_file = populated_fixture.example_file
     joint_fixture = populated_fixture.joint_fixture
+    object_id = populated_fixture.object_id
 
     # simplify testing by using one longer lived work order token
 
@@ -46,7 +47,10 @@ async def test_happy_journey(
     # (An check that an event is published indicating that the file is not in
     # outbox yet.)
     non_staged_requested_event = event_schemas.NonStagedFileRequested(
-        file_id=example_file.file_id, decrypted_sha256=example_file.decrypted_sha256
+        file_id=example_file.file_id,
+        target_object_id=object_id,
+        target_bucket_id=joint_fixture.config.outbox_bucket,
+        decrypted_sha256=example_file.decrypted_sha256,
     )
     async with joint_fixture.kafka.expect_events(
         events=[
@@ -68,15 +72,18 @@ async def test_happy_journey(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.config.outbox_bucket,
-            "object_id": example_file.file_id,
+            "object_id": object_id,
         }
     )
+
     await joint_fixture.s3.populate_file_objects([file_object])
 
     # retry the access request:
     # (An check that an event is published indicating that a download was served.)
     download_served_event = event_schemas.FileDownloadServed(
         file_id=example_file.file_id,
+        target_object_id=object_id,
+        target_bucket_id=joint_fixture.config.outbox_bucket,
         decrypted_sha256=example_file.decrypted_sha256,
         context="unknown",
     )
@@ -123,6 +130,7 @@ async def test_happy_deletion(
     """Simulates a typical, successful journey for file deletion."""
     drs_id = populated_fixture.drs_id
     joint_fixture = populated_fixture.joint_fixture
+    object_id = populated_fixture.object_id
 
     # place example content in the outbox bucket:
     file_object = file_fixture.copy(
@@ -150,7 +158,8 @@ async def test_happy_deletion(
         await data_repository.delete_file(file_id=drs_id)
 
     assert not await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.outbox_bucket, object_id=drs_id
+        bucket_id=joint_fixture.config.outbox_bucket,
+        object_id=object_id,
     )
 
 
@@ -166,7 +175,7 @@ async def test_cleanup(cleanup_fixture: CleanupFixture):  # noqa: F405,F811
     )
     assert await cleanup_fixture.joint_fixture.s3.storage.does_object_exist(
         bucket_id=cleanup_fixture.joint_fixture.config.outbox_bucket,
-        object_id=cached_object.file_id,
+        object_id=cached_object.object_id,
     )
 
     # check if expired object has been removed from outbox
@@ -175,5 +184,5 @@ async def test_cleanup(cleanup_fixture: CleanupFixture):  # noqa: F405,F811
     )
     assert not await cleanup_fixture.joint_fixture.s3.storage.does_object_exist(
         bucket_id=cleanup_fixture.joint_fixture.config.outbox_bucket,
-        object_id=expired_object.file_id,
+        object_id=expired_object.object_id,
     )

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -136,7 +136,7 @@ async def test_happy_deletion(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.config.outbox_bucket,
-            "object_id": drs_id,
+            "object_id": object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])


### PR DESCRIPTION
Added object_id to the DrsObject model, which is a uuid4 that gets assigned when consuming a FileInternallyRegistered event. 
In the DataRepository class, the _get_access_model(), access_drs_object(), cleanup_outbox(), and delete_file() were updated so the ID passed to any object_storage methods is now the object_id.