### PR TITLE
Fix auth configuration

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -292,7 +292,11 @@
       "title": "Auth Check Claims",
       "description": "A dict of all GHGA internal claims that shall be verified.",
       "default": {
-        "name": null,
+        "type": null,
+        "file_id": null,
+        "user_id": null,
+        "user_public_crypt4gh_key": null,
+        "full_user_name": null,
         "email": null,
         "iat": null,
         "exp": null

--- a/dcs/__init__.py
+++ b/dcs/__init__.py
@@ -17,4 +17,4 @@
 to serve files from localstack S3.
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/dcs/config.py
+++ b/dcs/config.py
@@ -45,7 +45,7 @@ class WorkOrderTokenConfig(AuthConfig):
 @config_from_yaml(prefix="dcs")
 class Config(
     ApiConfigBase,
-    AuthConfig,
+    WorkOrderTokenConfig,
     S3Config,
     DataRepositoryConfig,
     MongoDbConfig,

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -5,8 +5,12 @@ auth_algs:
 auth_check_claims:
   email: null
   exp: null
+  file_id: null
+  full_user_name: null
   iat: null
-  name: null
+  type: null
+  user_id: null
+  user_public_crypt4gh_key: null
 auth_key: '{}'
 auth_map_claims: {}
 auto_reload: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -259,7 +259,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 0.6.3
+  version: 0.6.4
 openapi: 3.0.2
 paths:
   /health:


### PR DESCRIPTION
The Config class used the wrong base class for the auth config (not the specific one for work package access tokens).

This was not detected in the tests because they had the config overridden with the proper one.