### PR TITLE
Fix/idempotency issues gsi 581

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dcs"
-version = "1.2.0"
+version = "1.2.1"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 dependencies = [
     "typer >= 0.9.0",

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/download-controller-service):
 ```bash
-docker pull ghga/download-controller-service:1.2.0
+docker pull ghga/download-controller-service:1.2.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/download-controller-service:1.2.0 .
+docker build -t ghga/download-controller-service:1.2.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -60,7 +60,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/download-controller-service:1.2.0 --help
+docker run -p 8080:8080 ghga/download-controller-service:1.2.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -201,7 +201,7 @@ info:
     \ Object Storage. \n\nThis is an implementation of the DRS standard from the Global\
     \ Alliance for Genomics and Health, please find more information at: https://github.com/ga4gh/data-repository-service-schemas"
   title: Download Controller Service
-  version: 1.2.0
+  version: 1.2.1
 openapi: 3.1.0
 paths:
   /health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dcs"
-version = "1.2.0"
+version = "1.2.1"
 description = "Download Controller Service - a GA4GH DRS-compliant service for delivering files from S3 encrypted according to the GA4GH Crypt4GH standard."
 dependencies = [
     "typer >= 0.9.0",

--- a/src/dcs/adapters/outbound/http/exceptions.py
+++ b/src/dcs/adapters/outbound/http/exceptions.py
@@ -28,17 +28,17 @@ class BadResponseCodeError(KnownError):
         super().__init__(message)
 
 
-class SecretNotFoundError(KnownError):
-    """Thrown when the secret with the id was not found"""
-
-    def __init__(self, *, secret_id):
-        message = f"The secret with the id {secret_id} was not found."
-        super().__init__(message)
-
-
 class RequestFailedError(KnownError):
     """Thrown when a request fails without returning a response code"""
 
     def __init__(self, *, url: str):
         message = f"The request to {url} failed."
+        super().__init__(message)
+
+
+class SecretNotFoundError(KnownError):
+    """Thrown when the secret with the id was not found"""
+
+    def __init__(self, *, secret_id):
+        message = f"The secret with the id {secret_id} was not found."
         super().__init__(message)

--- a/src/dcs/core/data_repository.py
+++ b/src/dcs/core/data_repository.py
@@ -16,6 +16,7 @@
 """Main business-logic of this service"""
 
 import contextlib
+import logging
 import re
 import uuid
 from datetime import timedelta
@@ -35,6 +36,8 @@ from dcs.core import models
 from dcs.ports.inbound.data_repository import DataRepositoryPort
 from dcs.ports.outbound.dao import DrsObjectDaoPort, ResourceNotFoundError
 from dcs.ports.outbound.event_pub import EventPublisherPort
+
+log = logging.getLogger(__name__)
 
 
 class DataRepositoryConfig(BaseSettings):
@@ -141,6 +144,7 @@ class DataRepository(DataRepositoryPort):
         try:
             drs_object_with_access_time = await self._drs_object_dao.get_by_id(drs_id)
         except ResourceNotFoundError as error:
+            log.error(f"Could not find object for DRS id {drs_id}")
             raise self.DrsObjectNotFoundError(drs_id=drs_id) from error
 
         drs_object = models.DrsObject(
@@ -156,12 +160,16 @@ class DataRepository(DataRepositoryPort):
                 s3_endpoint_alias
             )
         except KeyError as exc:
+            log.critical(
+                f"Could not get object storage accessor instance for alias '{s3_endpoint_alias}'."
+            )
             raise self.StorageAliasNotConfiguredError(alias=s3_endpoint_alias) from exc
 
         # check if the file corresponding to the DRS object is already in the outbox:
         if not await object_storage.does_object_exist(
             bucket_id=bucket_id, object_id=drs_object.object_id
         ):
+            log.info(f"File not in outbox for '{drs_id}'. Request staging...")
             # publish an event to request a stage of the corresponding file:
             await self._event_publisher.unstaged_download_requested(
                 drs_object=drs_object_with_uri,
@@ -176,8 +184,10 @@ class DataRepository(DataRepositoryPort):
         # Successfully staged, update access information now
         drs_object_with_access_time.last_accessed = utc_dates.now_as_utc()
         try:
+            log.debug(f"Updating time of last access for '{drs_id}'.")
             await self._drs_object_dao.update(drs_object_with_access_time)
         except ResourceNotFoundError as error:
+            # TODO: this is already checked above. Need to rethink what we do here
             raise self.DrsObjectNotFoundError(drs_id=drs_id) from error
 
         drs_object_with_access = await self._get_access_model(
@@ -191,6 +201,7 @@ class DataRepository(DataRepositoryPort):
             drs_object=drs_object_with_uri,
             target_bucket_id=bucket_id,
         )
+        log.info(f"Sent download served event for '{drs_id}'.")
 
         # CLI needs to have the encrypted size to correctly download all file parts
         encrypted_size = await object_storage.get_object_size(
@@ -207,29 +218,45 @@ class DataRepository(DataRepositoryPort):
         is met or exceeded, the corresponding file is removed from the outbox.
         """
         # Run on demand through CLI, so crashing should be ok if the alias is not configured
+        log.info(
+            f"Starting outbox cleanup for storage identified by alias '{s3_endpoint_alias}'."
+        )
         try:
             bucket_id, object_storage = self._object_storages.for_alias(
                 s3_endpoint_alias
             )
         except KeyError as exc:
+            log.critical(
+                f"Could not get object storage accessor instance for alias '{s3_endpoint_alias}'."
+            )
             raise self.StorageAliasNotConfiguredError(alias=s3_endpoint_alias) from exc
 
         threshold = utc_dates.now_as_utc() - timedelta(days=self._config.cache_timeout)
 
         # filter to get all files in outbox that should be removed
         object_ids = await object_storage.list_all_object_ids(bucket_id=bucket_id)
+        log.debug(
+            f"Retrieved list of deletion candidates for storage '{s3_endpoint_alias}'"
+        )
+
         for object_id in object_ids:
             try:
                 drs_object = await self._drs_object_dao.find_one(
                     mapping={"object_id": object_id}
                 )
             except ResourceNotFoundError as error:
+                log.critical(
+                    f"Inconsistent state: There is no database entry for object '{object_id}'."
+                )
                 raise self.CleanupError(
                     object_id=object_id, from_error=error
                 ) from error
 
             # only remove file if last access is later than cache timeout days ago
             if drs_object.last_accessed <= threshold:
+                log.info(
+                    f"Deleting object '{object_id}' from storage '{s3_endpoint_alias}'."
+                )
                 try:
                     await object_storage.delete_object(
                         bucket_id=bucket_id, object_id=object_id
@@ -238,6 +265,9 @@ class DataRepository(DataRepositoryPort):
                     object_storage.ObjectError,
                     object_storage.ObjectStorageProtocolError,
                 ) as error:
+                    log.critical(
+                        f"Could not remove object '{object_id}' due to storage issues."
+                    )
                     raise self.CleanupError(
                         object_id=object_id, from_error=error
                     ) from error
@@ -245,6 +275,14 @@ class DataRepository(DataRepositoryPort):
     async def register_new_file(self, *, file: models.DrsObjectBase):
         """Register a file as a new DRS Object."""
         object_id = str(uuid.uuid4())
+
+        with contextlib.suppress(ResourceNotFoundError):
+            await self._drs_object_dao.get_by_id(file.file_id)
+            log.error(
+                f"Could not register file with id '{file.file_id}' as an entry already exists for this id."
+            )
+            return
+
         drs_object = models.DrsObject(**file.model_dump(), object_id=object_id)
 
         file_with_access_time = models.AccessTimeDrsObject(
@@ -253,10 +291,14 @@ class DataRepository(DataRepositoryPort):
         )
         # write file entry to database
         await self._drs_object_dao.insert(file_with_access_time)
+        log.info(
+            f"Successfully registered file with id '{file.file_id}' in the database."
+        )
 
         # publish message that the drs file has been registered
         drs_object_with_uri = self._get_model_with_self_uri(drs_object=drs_object)
         await self._event_publisher.file_registered(drs_object=drs_object_with_uri)
+        log.info(f"Sent successful registration event for file id '{file.file_id}'.")
 
     async def serve_envelope(self, *, drs_id: str, public_key: str) -> str:
         """
@@ -269,6 +311,7 @@ class DataRepository(DataRepositoryPort):
         except ResourceNotFoundError as error:
             raise self.DrsObjectNotFoundError(drs_id=drs_id) from error
 
+        log.info(f"Retrieving file envelope for DRS id '{drs_id}'.")
         try:
             envelope = get_envelope_from_ekss(
                 secret_id=drs_object.decryption_secret_id,
@@ -299,6 +342,7 @@ class DataRepository(DataRepositoryPort):
         try:
             drs_object = await self._drs_object_dao.get_by_id(id_=file_id)
         except ResourceNotFoundError:
+            log.info(f"File with id '{file_id}' has already been deleted.")
             # If the db entry does not exist, we are done, as it is deleted last
             # and has already been deleted before
             return
@@ -309,6 +353,7 @@ class DataRepository(DataRepositoryPort):
                 secret_id=drs_object.decryption_secret_id,
                 api_base=self._config.ekss_base_url,
             )
+            log.debug(f"Successfully deleted secret for '{file_id}' from EKSS.")
 
         # At this point the alias is contained in the database and this is not a user
         # error, but a configuration issue. Is crashing the REST service ok here or do we
@@ -317,6 +362,9 @@ class DataRepository(DataRepositoryPort):
         try:
             bucket_id, object_storage = self._object_storages.for_alias(alias)
         except KeyError as exc:
+            log.critical(
+                f"Could not get object storage accessor instance for alias '{alias}'."
+            )
             raise self.StorageAliasNotConfiguredError(alias=alias) from exc
 
         # Try to remove file from S3
@@ -324,8 +372,12 @@ class DataRepository(DataRepositoryPort):
             await object_storage.delete_object(
                 bucket_id=bucket_id, object_id=drs_object.object_id
             )
+            log.debug(
+                f"Successfully deleted file object for '{file_id}' from object storage identified by '{alias}'."
+            )
 
         # Remove file from database and send success event
         # Should not fail as we got the DRS object by the same ID
         await self._drs_object_dao.delete(id_=file_id)
         await self._event_publisher.file_deleted(file_id=file_id)
+        log.info(f"Successfully deleted entries for file with id '{file_id}'.")

--- a/src/dcs/core/data_repository.py
+++ b/src/dcs/core/data_repository.py
@@ -187,7 +187,7 @@ class DataRepository(DataRepositoryPort):
             log.debug(f"Updating time of last access for '{drs_id}'.")
             await self._drs_object_dao.update(drs_object_with_access_time)
         except ResourceNotFoundError as error:
-            # TODO: this is already checked above. Need to rethink what we do here
+            # This should not happen, as we already check for the existence above
             raise self.DrsObjectNotFoundError(drs_id=drs_id) from error
 
         drs_object_with_access = await self._get_access_model(

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -271,7 +271,7 @@ async def populated_fixture(
     )
     # just check the first payload, assume the second one is also correct
     file_registered_event = event_schemas.FileRegisteredForDownload(
-        **recorder.recorded_events[0].payload
+        **recorder.recorded_events[0].payload  # type: ignore
     )
     assert file_registered_event.file_id == EXAMPLE_FILE.file_id
     assert file_registered_event.decrypted_sha256 == EXAMPLE_FILE.decrypted_sha256

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -271,7 +271,7 @@ async def populated_fixture(
     )
     # just check the first payload, assume the second one is also correct
     file_registered_event = event_schemas.FileRegisteredForDownload(
-        **recorder.recorded_events[0].payload  # type: ignore
+        **recorder.recorded_events[0].payload
     )
     assert file_registered_event.file_id == EXAMPLE_FILE.file_id
     assert file_registered_event.decrypted_sha256 == EXAMPLE_FILE.decrypted_sha256


### PR DESCRIPTION
Fixed some minor behaviour issue with file registration, i.e. consuming the same event twice would crash the DCS on insertion previously. Now there's a lookup in the databse and error level logging instead to gracefully handle that case.

In addition , some degree of logging was introduced throughout the `data_repository`.
Version is now 1.2.1 as this is more of a patch than enhancement.